### PR TITLE
fix: Separate timestamp for local state to avoid API BadRequestError

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -23,8 +23,10 @@ export default function Home() {
 
   const sendMessage = async () => {
     if (message.trim()) {
-      const newMessage = { role: 'user', content: message};
-      setMessages([...messages, newMessage]);
+      const timestamp = dayjs().format('HH:mm:ss');
+      const localMessage = { role: 'user', content: message, timestamp };
+      const apiMessage = { role: 'user', content: message };
+      setMessages([...messages, localMessage]);
       setMessage('');
 
       try {
@@ -33,7 +35,7 @@ export default function Home() {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ messages: [...messages, newMessage] }),
+          body: JSON.stringify({ messages: [...messages.map(msg => ({ role: msg.role, content: msg.content })), apiMessage] }),
         });
 
         if (!response.ok) {
@@ -47,7 +49,7 @@ export default function Home() {
 
         setMessages((prevMessages) => [
           ...prevMessages,
-          { role: 'assistant', content: updatedMessage, id: messageId},
+          { role: 'assistant', content: updatedMessage, id: messageId, timestamp: dayjs().format('HH:mm:ss') }
         ]);
 
         while (true) {
@@ -178,6 +180,9 @@ export default function Home() {
                   }}
                 >
                   {msg.content}
+                  <Typography variant="body2" color="textSecondary" sx={{ textAlign: 'right', marginTop: '8px' }}>
+                    {msg.timestamp}
+                    </Typography>
                 </Box>
               </Box>
             ))}


### PR DESCRIPTION
This PR addresses an issue where the `timestamp` property in the `messages` object was causing a `BadRequestError` when sent to the API. The solution involves separating the data used for local state (which includes the `timestamp`) from the data sent to the API (which excludes the `timestamp`). 

**Changes**
- Added separate `localMessage` and `apiMessage` objects in the `sendMessage` function.
- Updated the API request to only send necessary properties (excluding `timestamp`).
- Ensured that the `timestamp` is still displayed in the chatbox for local UI purposes.

This fix allows the timestamp to be displayed locally without causing errors when interacting with the API.
